### PR TITLE
break change. Modified core cli to add option -profile as required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,18 @@ pip install aws-net-scan
 ## How to use:
 
 The cli will use the AWS profiles you configured wit aws cli that you have already defined in '~/.aws/' and by default it'll use the 'default' aws [profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html), if you want a concrete profile or just info about a concrete vpc run the following commands:
-```sh
-aws-net-scan
-```
+
 ```sh
 aws-net-scan --help
 ```
+- Required parameter:
+
+```sh
+aws-net-scan --region eu-west-1
+```
+
+- Optional parameters:
+
 ```sh
 aws-net-scan --profile name_profile
 ```


### PR DESCRIPTION
Now --region is required because using the region in 'config' file generated aws responses errors sometimes, even being the same region, so in order to avoid errors to users this parameter should be required.